### PR TITLE
feat(repo): sync cluster state and add controller node-selector

### DIFF
--- a/clusters/homelab/aitrade-flux.yaml
+++ b/clusters/homelab/aitrade-flux.yaml
@@ -5,11 +5,10 @@ metadata:
   name: aitrade-flux
   namespace: flux-system
 spec:
-  # Suspended initially. Resume only after:
-  #   1. Flux bootstrap is complete.
-  #   2. The sops-age Secret exists in flux-system.
-  #   3. The aitrade-auth.sops.yaml file is encrypted and committed.
-  suspend: true
+  # Live: applied by the homelab-managed Flux on the homelab cluster.
+  # Initial cutover was completed; the suspend flag is removed so future
+  # ai-trade master commits are picked up automatically.
+  suspend: false
   interval: 10m0s
   path: ./aitrade
   prune: true

--- a/clusters/homelab/aitrade/image-automation.yaml
+++ b/clusters/homelab/aitrade/image-automation.yaml
@@ -5,9 +5,9 @@ metadata:
   name: aitrade
   namespace: flux-system
 spec:
-  # Suspended initially. Resume only after the full cutover is verified
-  # and ai-trade is running under Flux control.
-  suspend: true
+  # Live: image automation is active. Tag bumps from the ImagePolicy
+  # flow into ai-trade master via the Setters strategy on the prod overlay.
+  suspend: false
   interval: 10m0s
   sourceRef:
     kind: GitRepository

--- a/clusters/homelab/flux-system/kustomization.yaml
+++ b/clusters/homelab/flux-system/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
 - gotk-components.yaml
 - gotk-sync.yaml
+patches:
+  - path: patches/controller-node-selector.yaml

--- a/docs/runbooks/flux-cutover.md
+++ b/docs/runbooks/flux-cutover.md
@@ -1,11 +1,17 @@
 # Flux Cutover Runbook — ai-trade Migration
 
-> **Status**: Planning / Not yet executed.
->
-> This runbook describes the staged cutover of ai-trade from its current
-> Flux setup (in the ai-trade repo) to the new Flux setup managed from
-> homelab-k8s. All resources have been pre-created with `suspend: true`
-> to prevent premature reconciliation.
+> **Status**: Cutover complete. Runbook kept for the actual flow that
+> worked and as a reference for future cluster re-provisioning.
+
+## Post-cutover notes
+
+- `Secret/sops-age` and `Secret/ghcr-pull` were applied out-of-band
+  during cutover and remain in the cluster only. They are not yet in
+  the repo. The plan is to move them into Vaultwarden when Vaultwarden
+  is brought up; see `docs/runbooks/vaultwarden.md` and follow-up issue.
+- `Kustomization/aitrade-flux`, `Kustomization/aitrade-prod`, and
+  `ImageUpdateAutomation/aitrade` are now `suspend: false` in the repo
+  to match the cluster.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
Sync homelab repo manifests with the actual cluster state after the
ai-trade cutover. The cluster was set up out-of-band and the repo had
not fully reflected what was running.

## Changes
- `clusters/homelab/aitrade-flux.yaml`: remove `suspend: true` to match the cluster
- `clusters/homelab/aitrade/image-automation.yaml`: remove `suspend: true` to match the cluster
- `clusters/homelab/flux-system/kustomization.yaml`: wire the controller node-selector patch (the patch file was already in the repo)
- `docs/runbooks/flux-cutover.md`: update status to "cutover complete" and add post-cutover notes

## Out of scope (deferred)
- `Secret/sops-age` and `Secret/ghcr-pull` are not yet in the repo. They will be moved into Vaultwarden when Vaultwarden is brought up. See follow-up issue to be opened.
- The leaked `ghcr-pull` PAT in the cluster is treated as compromised. It will be rotated after merge.

## Validation
- `kubectl kustomize clusters/homelab`
- `kubectl kustomize clusters/homelab/aitrade`
- `kubectl kustomize infrastructure/vaultwarden`
All three build cleanly.

## Cutover gate
After merge, the cluster will reconcile the new `suspend: false` state
on the next 10m tick. No manual cutover is required.
