### PR TITLE
fix(aitrade-flux): correct path is repo-root relative

### DIFF
--- a/clusters/homelab/aitrade-flux.yaml
+++ b/clusters/homelab/aitrade-flux.yaml
@@ -8,9 +8,10 @@ spec:
   # Live: applied by the homelab-managed Flux on the homelab cluster.
   # Initial cutover was completed; the suspend flag is removed so future
   # ai-trade master commits are picked up automatically.
+  # Path is relative to the GitRepository root (not the parent Kustomization).
   suspend: false
   interval: 10m0s
-  path: ./aitrade
+  path: ./clusters/homelab/aitrade
   prune: true
   wait: true
   timeout: 5m0s


### PR DESCRIPTION
## Summary
Fix `path: ./aitrade` in `clusters/homelab/aitrade-flux.yaml`.
The path is relative to the GitRepository root, not the parent
Kustomization. The directory is at `clusters/homelab/aitrade/`.

## Symptom
After merging #11, the cluster's
`Kustomization/aitrade-flux` errored with
`kustomization path not found: stat /tmp/.../aitrade: no such file`.

## Fix
`path: ./aitrade` -> `path: ./clusters/homelab/aitrade`
